### PR TITLE
Story 6522 run make sofar twice to build preproc tools [ch6522]

### DIFF
--- a/.github/workflows/.dockerignore
+++ b/.github/workflows/.dockerignore
@@ -1,0 +1,3 @@
+manual
+regtests
+smc_docs

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -1,0 +1,37 @@
+name: Docker build
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+      - 'release-[0-9]+.[0-9]+.[0-9]+'
+      - 'story-*-[0-9]+.[0-9]+.[0-9]+'
+      - 'bug-*-[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_ACCESS_KEY_SECRET }}
+          aws-region: us-east-1
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Get tag name
+        id: get-tag-name
+        run: echo ::set-output name=IMAGE_TAG::${GITHUB_REF/refs\/tags\//}
+
+      - name: Build, tag, and push image to Amazon ECR
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: ww3
+        run: |
+            docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:${{ steps.get-tag-name.outputs.IMAGE_TAG }} .
+            docker push $ECR_REGISTRY/$ECR_REPOSITORY:${{ steps.get-tag-name.outputs.IMAGE_TAG }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,7 @@ RUN apt-get -yq install build-essential gfortran mpich curl
 # download tarball of sofarmaster branch &
 # rename the directory to WW3 for ease of use
 # then clear out some unused documentation files
-RUN curl -L https://github.com/wavespotter/WW3/archive/sofarmaster.tar.gz | tar zx 
-RUN mv /WW3-sofarmaster /WW3
+COPY . /WW3
 RUN rm -rf /WW3/manual /WW3/regtests /WW3/smc_docs
 
 WORKDIR /WW3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# ---------------------------------------------------- #
+# This image compiles a version of the Wave Watch III
+# model optimized for the Sofar use cases and intended 
+# for benchmarking and other lightweight applications.
+
+FROM ubuntu:18.04 AS stage1
+
+RUN apt-get update
+RUN apt-get -yq install build-essential gfortran mpich curl
+
+# download tarball of sofarmaster branch &
+# rename the directory to WW3 for ease of use
+# then clear out some unused documentation files
+RUN curl -L https://github.com/wavespotter/WW3/archive/sofarmaster.tar.gz | tar zx 
+RUN mv /WW3-sofarmaster /WW3
+RUN rm -rf /WW3/manual /WW3/regtests /WW3/smc_docs
+
+WORKDIR /WW3
+
+RUN yes n | ./model/bin/w3_setup model
+RUN cd ./model/bin/ && ./make_Sofar
+
+RUN apt-get -yq remove build-essential curl
+
+# Stage 2
+FROM ubuntu:18.04
+COPY --from=stage1 /WW3 /WW3
+COPY --from=stage1 /usr/lib/* /usr/lib/
+COPY --from=stage1 /lib/* /lib/
+COPY --from=stage1 /lib64/* /lib64/
+COPY --from=stage1 /usr/bin/mpiexec /usr/bin/hydra_pmi_proxy /usr/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ RUN rm -rf /WW3/manual /WW3/regtests /WW3/smc_docs
 WORKDIR /WW3
 
 RUN yes n | ./model/bin/w3_setup model
-RUN cd ./model/bin/ && ./make_Sofar
+# you need to run make_Sofar twice to get the preprocessing tools to build
+RUN cd ./model/bin/ && ./make_Sofar && ./make_Sofar
 
 RUN apt-get -yq remove build-essential curl
 


### PR DESCRIPTION
This PR just moves the Dockerfile from the `wavewatch` repo to where it naturally should belong (i.e. here). The `make_Sofar` also needed to run two times to build the `ww3_grid` and `ww3_prep`. @pieterbartsmit this should have no effect on your operations (just added you as a reviewer for awareness).