### PR TITLE
add aws cli to docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ FROM ubuntu:18.04 AS stage1
 
 
 RUN apt-get update
-RUN apt-get -yq install build-essential gcc gfortran mpich curl libnetcdf-dev libnetcdff-dev
+RUN apt-get -yq install build-essential gcc gfortran mpich curl libnetcdf-dev libnetcdff-dev aws-cli
 
 # set environmental variables
 # for netcdf4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,12 @@
 # ---------------------------------------------------- #
 # This image compiles a version of the Wave Watch III
-# model optimized for the Sofar use cases and intended 
-# for benchmarking and other lightweight applications.
+# model optimized for the Sofar use cases. It's compiled
+# with NetCDF 4 support.
 
 FROM ubuntu:18.04 AS stage1
 
-
-
 RUN apt-get update
-RUN apt-get -yq install build-essential gcc gfortran mpich curl libnetcdf-dev libnetcdff-dev aws-cli
+RUN DEBIAN_FRONTEND="noninteractive" TZ="Etc/UTC" apt-get -yq install build-essential gcc gfortran mpich curl libnetcdf-dev libnetcdff-dev awscli
 
 # set environmental variables
 # for netcdf4

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 FROM ubuntu:18.04 AS stage1
 
 RUN apt-get update
-RUN DEBIAN_FRONTEND="noninteractive" TZ="Etc/UTC" apt-get -yq install build-essential gcc gfortran mpich curl libnetcdf-dev libnetcdff-dev awscli
+RUN apt-get -yq install build-essential gcc gfortran mpich curl libnetcdf-dev libnetcdff-dev
 
 # set environmental variables
 # for netcdf4
@@ -14,10 +14,9 @@ ENV NCDIR /usr/include/netcdf
 ENV WWATCH3_NETCDF NC4
 ENV NETCDF_CONFIG /usr/bin/nf-config
 
-# download tarball of sofarmaster branch &
-# rename the directory to WW3 for ease of use
-# then clear out some unused documentation files
+
 COPY . /WW3
+# clear out some unused documentation files
 RUN rm -rf /WW3/manual /WW3/regtests /WW3/smc_docs
 
 WORKDIR /WW3
@@ -35,3 +34,4 @@ COPY --from=stage1 /usr/lib/* /usr/lib/
 COPY --from=stage1 /lib/* /lib/
 COPY --from=stage1 /lib64/* /lib64/
 COPY --from=stage1 /usr/bin/mpiexec /usr/bin/hydra_pmi_proxy /usr/bin/
+RUN apt-get update && DEBIAN_FRONTEND="noninteractive" TZ="Etc/UTC"  apt-get -yq install awscli && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
re [ch7592](https://app.clubhouse.io/sofar/story/7592/add-awscli-to-ww3-input-processing-ww3-docker-images)

adding aws-cli increases the image size ~100mb compressed, which isn't great, but I think the python dependencies bloat it a bit. A nice TODO would be to bring this size down again, but I don't want it blocking anything.