### PR TITLE
add NETCDFF_CONFIG and use it where appropriate

### DIFF
--- a/model/bin/README.md
+++ b/model/bin/README.md
@@ -39,9 +39,13 @@ WW3_PARCOMPN = <how many parallel make tasks to use, default to 4 if not set >
 The requirements for NetCDF are: 
 * NetCDF version 4.1.1 or higher (Use "nc-config --version" to check) 
 * NetCDF-4 API enabled (Use "nc-config --has-nc4" to check) 
-* Define NETCDF_CONFIG env variable
+* Define `NETCDF_CONFIG` env variable
+* Define `NETCDFF_CONFIG` env variable
 
-NETCDF_CONFIG = < path to NetCDF-4 nc-config utility >
+`NETCDF_CONFIG` = < path to NetCDF-4 nc-config utility >
+`NETCDFF_CONFIG` = < path to NetCDF-4 nf-config utility >
+
+>**Note:**  (Camille Teicheira 2023-07-26): as of [netcdf-c 4.9.2](https://github.com/Unidata/netcdf-c/blob/main/RELEASE_NOTES.md?plain=1#L29) `nc-config` no longer looks for and returns values from `nf-config` if enabled, so we need to be specific and provide both utilities. If using a version of NetCDF < 4.9.2, `NETCDFF_CONFIG` is optional and will be set to the value provided for `NETCDF_CONFIG`.
 
 ## To use the PDLIB switch:
 

--- a/model/bin/comp.tmpl
+++ b/model/bin/comp.tmpl
@@ -77,9 +77,15 @@
   fi
 
   # netcdf include dir
+  # NOTE (Camille Teicheira 2023-07-26):
+  # NETCDFF_CONFIG should be the path to `nf-config`
+  # NETDCDF_CONFIG should be the path to `nc-config`
+  # as of netcdf-c 4.9.2 nc-config no longer looks for and returns
+  # values from nf-config if enabled, so we need to be specific
+  # https://github.com/Unidata/netcdf-c/blob/main/RELEASE_NOTES.md?plain=1#L29
   if [ "$netcdf_compile" = 'yes' ]
   then
-    if [ "$mpi_mod" = 'no' ]; then comp="`$NETCDF_CONFIG --fc`"; fi
+    if [ "$mpi_mod" = 'no' ]; then comp="`$NETCDFF_CONFIG --fc`"; fi
     opt="$opt `$NETCDF_CONFIG --cflags`"
   fi
 

--- a/model/bin/link.tmpl
+++ b/model/bin/link.tmpl
@@ -112,9 +112,15 @@
   fi
 
   # netcdf library dir
+  # NOTE (Camille Teicheira 2023-07-26):
+  # NETCDFF_CONFIG should be the path to `nf-config`
+  # NETDCDF_CONFIG should be the path to `nc-config`
+  # as of netcdf-c 4.9.2 nc-config no longer looks for and returns
+  # values from nf-config if enabled, so we need to be specific
+  # https://github.com/Unidata/netcdf-c/blob/main/RELEASE_NOTES.md?plain=1#L29
   if [ "$netcdf_compile" = 'yes' ] ; then
-    if [ "$mpi_mod" = 'no' ]; then comp="`$NETCDF_CONFIG --fc`"; fi
-    libs="$libs `$NETCDF_CONFIG --flibs` `$NETCDF_CONFIG --libs`"
+    if [ "$mpi_mod" = 'no' ]; then comp="`$NETCDFF_CONFIG --fc`"; fi
+    libs="$libs `$NETCDFF_CONFIG --flibs` `$NETCDF_CONFIG --libs`"
   fi
 
   # scotch library 

--- a/model/bin/w3_make
+++ b/model/bin/w3_make
@@ -330,7 +330,7 @@ EOF
       return 1
     else
       netcdf_compile_message
-      echo "$mode: NETCDFF_CONFIG not defined; using NETCDF_CONFIG value"; echo ' '
+      echo "$mode: NETCDFF_CONFIG not defined; using NETCDF_CONFIG value: $NETCDF_CONFIG"; echo ' '
       NETCDFF_CONFIG=$NETCDF_CONFIG
     fi
   fi

--- a/model/bin/w3_make
+++ b/model/bin/w3_make
@@ -273,8 +273,9 @@ For compiling with NetCDF, the following environment variable
 is required:
 
     NETCDF_CONFIG = <path to NetCDF-4 nc-config utility>
+    NETCDFF_CONFIG = <path to NetCDF-4 nf-config utility>
 
-The nc-config utility (part of the NetCDF-4 install) is used to
+The nc-config and nf-config utilities (part of the NetCDF-4 install) is used to
 determine the appropriate compile and link flags.
 
 For NetCDF routines to compile, WAVEWATCH III requires
@@ -317,6 +318,21 @@ EOF
     netcdf_compile_message
     echo "$mode: NetCDF version $netcdf_version < 4.1.1"; echo ' '
     return 1
+  fi
+
+
+  if [ -z "$NETCDFF_CONFIG" ]
+  then
+    if [ `echo $netcdf_version | tr -d . | tr -d - | tr -d 'A-Z a-z'` -gt 491 ]
+    then
+      netcdf_compile_message
+      echo "$mode: NetCDF version $netcdf_version > 4.9.1 and NETCDFF_CONFIG is not defined. NETCDFF_CONFIG must be defined for NetCDF versions > 4.9.1"; echo ' '
+      return 1
+    else
+      netcdf_compile_message
+      echo "$mode: NETCDFF_CONFIG not defined; using NETCDF_CONFIG value"; echo ' '
+      NETCDFF_CONFIG=$NETCDF_CONFIG
+    fi
   fi
 
   return 0

--- a/model/esmf/Makefile
+++ b/model/esmf/Makefile
@@ -13,7 +13,8 @@ SWITCHES := $(shell cat switch)
 
 WWATCH3_ENV := $(WW3_BINDIR)/wwatch3.env
 NETCDF_CONFIG := $(shell which nc-config)
-export WWATCH3_ENV NETCDF_CONFIG
+NETCDFF_CONFIG := $(shell which nf-config)
+export WWATCH3_ENV NETCDF_CONFIG NETCDFF_CONFIG
 
 EXE := $(WW3_EXEDIR)/ww3_multi_esmf
 


### PR DESCRIPTION
As of [`netcdf-c 4.9.2`](https://github.com/Unidata/netcdf-c/blob/main/RELEASE_NOTES.md#492---march-14-2023) the ability to access `nf-config` values via `nc-config` is no longer supported. For example, the commands `nc-config --flibs` or `nc-config --fc` no longer work. See this [outdated documentation for more examples](https://www.unidata.ucar.edu/software/netcdf/workshops/most-recent/utilities/Nc-config.html).

This behavior is currently hardcoded into the generation of the WW3 NetCDF pre- and post-processing executables. This PR adds a new environment variable `NETCDFF_CONFIG` whose value should be the path of `nf-config`. This environment variable will be required for versions of NetCDF-c > 4.9.1. 

I think this a a fix that should also make it's way into the main repo (https://github.com/NOAA-EMC/WW3) but I need to do some testing first.