### PR TITLE
Experimental wind-speed-dependent betamax for ST4

### DIFF
--- a/model/src/w3src4md.F90
+++ b/model/src/w3src4md.F90
@@ -550,6 +550,12 @@ CONTAINS
     REAL                    :: COSU, SINU, TAUX, TAUY, USDIRP, USTP
     REAL                    :: TAUPX, TAUPY, UST2, TAUW, TAUWB
     REAL   , PARAMETER      :: EPS1 = 0.00001, EPS2 = 0.000001
+    REAL                    :: BBETA_EFF        !PBS: The effective "betamax" after we apply a linear approximation.
+                                                !     Part of SOFAR enhancements to be able to better calibrate betamax
+                                                !     Estimated as BBETA_EFF= BETAMAX_INTERCEPT + BETAMAX_SLOPE * U
+    REAL   , PARAMETER      :: BETAMAX_INTERCEPT=1.43 ! Intercept of the linear betamax relation
+    REAL   , PARAMETER      :: BETAMAX_SLOPE=0.0 ! Slope of the linear betamax relation
+      
     REAL                    :: Usigma           !standard deviation of U due to gustiness
     REAL                    :: USTARsigma       !standard deviation of USTAR due to gustiness
     REAL                    :: CM,UCN,ZCN, &
@@ -599,9 +605,11 @@ CONTAINS
     STRESSSTABN =0.
     !
     ! Coupling coefficient times density ratio DRAT
-    !
-    CONST1=BBETA/KAPPA**2  ! needed for the tail
-    CONST0=CONST1*DRAT     ! needed for the resolved spectrum
+    ! PBS: Instead of a constant betamax we use a betamax linearly dependent on wind speed to allow for more flexibility
+    !      in calibration. (SOFAR SPECIFIC)
+    BBETA_EFF = BETAMAX_INTERCEPT + BETAMAX_SLOPE * MIN(U, 25.0)
+    CONST1=BBETA_EFF/KAPPA**2  ! needed for the tail
+    CONST0=CONST1*DRAT          ! needed for the resolved spectrum
     !
     ! 1.a  estimation of surface roughness parameters
     !
@@ -954,6 +962,10 @@ CONTAINS
         TAU1 =(TAUHFT(IND,J)*DELI2+TAUHFT(IND+1,J)*DELI1 )*DELJ2 &
              +(TAUHFT(IND,J+1)*DELI2+TAUHFT(IND+1,J+1)*DELI1)*DELJ1
       END IF
+
+      ! PBS - SOFAR: Because we recompute betamax based on windspeed we have to reschale the tabulated tail
+      !              contributions with the new betamax value
+      TAU1 = TAU1 * (BBETA_EFF / BBETA)
       !
       TAUHF = LEVTAIL0*UST**2*TAU1
     END IF ! End of test on use of table


### PR DESCRIPTION
# Experimental wind-speed-dependent betamax for ST4

Implements a linear wind-speed-dependent betamax relation for the ST4 wind input source term:

betamax_eff = BETAMAX_INTERCEPT + BETAMAX_SLOPE * min(U10, 25.0)

This is motivated by a known condition-dependent bias: the current single-value betamax is biased slightly high at moderate winds and low at high winds. The 25 m/s cap reflects the limits of reliable air-sea physics and Spotter wind estimates. See [notion page](https://app.notion.com/p/sofarocean/Beta-max-as-a-function-of-wind-speed-37c8ff95945080789e12cadb62ac0e4a) for further details

## Implementation

The change is currently hardcoded in w3src4md.F90 for testing purposes (BETAMAX_INTERCEPT=1.43, BETAMAX_SLOPE=0.0). With BETAMAX_SLOPE=0.0 the behaviour is bit-for-bit identical to the current code. **The namelist BETAMAX parameter is bypassed**. We will have to update these values during testing.

The HF tail stress lookup table is built at initialisation with a fixed betamax. Since the table entries scale linearly with betamax, the table results are rescaled on lookup by BBETA_EFF / BBETA before use — this keeps the tail stress consistent with the resolved-spectrum computation at no meaningful cost.

Not changed

Namelist parameters (BETAMAX still read and stored as before)
Model definition file format
Restart file format

# Follow-up work
If it works, we can consider promoting to proper namelist parameters (BETAMAX_INTERCEPT, BETAMAX_SLOPE) with corresponding updates to w3gdatmd.F90, w3gridmd.F90, w3iogrmd.F90, and ww3_ounf.F90.


